### PR TITLE
Enhancement: Allow specifying the actual reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A GitHub action to create [Deployments](https://developer.github.com/v3/repos/de
 | `target_url`     | (Optional) The target URL. This should be the URL of the app once deployed                                                                                                                                                                                                                                                                                                                                    |
 | `description`    | (Optional) A description to give the environment                                                                                                                                                                                                                                                                                                                                                              |
 | `auto_merge`     | (Optional - default is `false`) Whether to attempt to auto-merge the default branch into the branch that the action is running on if set to `"true"`. More details in the [GitHub deployments API](https://developer.github.com/v3/repos/deployments/#parameters-1). Warning - setting this to `"true"` has caused this action to [fail in some cases](https://github.com/chrnorm/deployment-action/issues/1) |
+| `ref`            | (Optional) The ref to deploy. This can be a branch, tag, or SHA. More details in the [GitHub deployments API](https://developer.github.com/v3/repos/deployments/#parameters-1). |
 
 ## Action outputs
 

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   initial_status:
     description: "Initial status for the deployment"
     default: "pending"
+  ref:
+    description: "The reference for the deployment"
+    required: false
   token:
     description: "Github repository token"
   target_url:

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ async function run() {
     const logUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}/checks`;
 
     const token = core.getInput("token", { required: true });
+    const ref = core.getInput("ref", { required: false }) || context.ref;
     const url = core.getInput("target_url", { required: false }) || logUrl;
     const environment =
       core.getInput("environment", { required: false }) || "production";
@@ -35,7 +36,7 @@ async function run() {
     const deployment = await client.repos.createDeployment({
       owner: context.repo.owner,
       repo: context.repo.repo,
-      ref: context.ref,
+      ref: ref,
       required_contexts: [],
       environment,
       transient_environment: true,


### PR DESCRIPTION
This PR

* [x] allows specifying a `ref`

💁‍♂ We are using this action for a `pull_request` event, but we actually deploy a different reference than what would be the reference for the context - it would be nice if we could specify the actual reference here as well!