### PR TITLE
Implement transient_environment and production_environment parameters

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,8 +28,23 @@ async function run() {
     const autoMergeStringInput = core.getInput("auto_merge", {
       required: false
     });
+    const isTransientEnvironmentStringInput = core.getInput("transient_environment", {
+      required: false,
+    });
+    const isProductionEnvironmentStringInput = core.getInput("production_environment", {
+      required: false,
+    });
 
     const auto_merge: boolean = autoMergeStringInput === "true";
+
+    const transient_environment: boolean = isTransientEnvironmentStringInput === "true";
+
+    // Use undefined to signal, that the default behaviour should be used.
+    const production_environment: boolean | undefined = isProductionEnvironmentStringInput === "true" 
+      ? true
+      : isProductionEnvironmentStringInput === "false"
+      ? false 
+      : undefined;
 
     const client = new github.GitHub(token, { previews: ["flash", "ant-man"] });
 
@@ -39,7 +54,8 @@ async function run() {
       ref: ref,
       required_contexts: [],
       environment,
-      transient_environment: true,
+      transient_environment,
+      production_environment,
       auto_merge,
       description
     });


### PR DESCRIPTION
This action previously set `transient_environment` to true, even though thats not the default. This change assumes transient to be false by default. Therefore this would be a major / breaking change. I think it's generally good and intuitive to use the API defaults, but if requested this could be reversed.

I wasn't sure how to format the ternaries, as this repo doesn't use prettier, or if i should use a different style.

I have not yet tested it, but will do so soon.