### PR TITLE
Add description to initial deploy status

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -47,6 +47,7 @@ async function run() {
     await client.repos.createDeploymentStatus({
       ...context.repo,
       deployment_id: deployment.data.id,
+      description,
       state: initialStatus,
       log_url: logUrl,
       environment_url: url


### PR DESCRIPTION
Reuses the provided deployment description as the initial status instead of leaving it blank