### PR TITLE
Add environment_url and log_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ A GitHub action to create [Deployments](https://developer.github.com/v3/repos/de
 
 ## Action inputs
 
-| name             | description                                                                                                                                                                                                                                                                                                                                                                                                   |
-| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `initial_status` | (Optional) Initial status for the deployment. Must be one of the [accepted strings](https://developer.github.com/v3/repos/deployments/#create-a-deployment-status)                                                                                                                                                                                                                                            |
-| `token`          | GitHub token                                                                                                                                                                                                                                                                                                                                                                                                  |
-| `target_url`     | (Optional) The target URL. This should be the URL of the app once deployed                                                                                                                                                                                                                                                                                                                                    |
-| `description`    | (Optional) A description to give the environment                                                                                                                                                                                                                                                                                                                                                              |
-| `auto_merge`     | (Optional - default is `false`) Whether to attempt to auto-merge the default branch into the branch that the action is running on if set to `"true"`. More details in the [GitHub deployments API](https://developer.github.com/v3/repos/deployments/#parameters-1). Warning - setting this to `"true"` has caused this action to [fail in some cases](https://github.com/chrnorm/deployment-action/issues/1) |
-| `ref`            | (Optional) The ref to deploy. This can be a branch, tag, or SHA. More details in the [GitHub deployments API](https://developer.github.com/v3/repos/deployments/#parameters-1). |
+| name              | description                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `initial_status`  | (Optional) Initial status for the deployment. Must be one of the [accepted strings](https://developer.github.com/v3/repos/deployments/#create-a-deployment-status)                                                                                                                                                                                                                                            |
+| `token`           | GitHub token                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `log_url`         | (Optional) Sets the URL for deployment output                                                                                                                                                                                                                                                                                                                                                                 |
+| `description`     | (Optional) Descriptive message about the deployment                                                                                                                                                                                                                                                                                                                                                           |
+| `environment_url` | (Optional) Sets the URL for accessing your environment                                                                                                                                                                                                                                                                                                                                                        |
+| `auto_merge`      | (Optional - default is `false`) Whether to attempt to auto-merge the default branch into the branch that the action is running on if set to `"true"`. More details in the [GitHub deployments API](https://developer.github.com/v3/repos/deployments/#parameters-1). Warning - setting this to `"true"` has caused this action to [fail in some cases](https://github.com/chrnorm/deployment-action/issues/1) |
+| `ref`             | (Optional) The ref to deploy. This can be a branch, tag, or SHA. More details in the [GitHub deployments API](https://developer.github.com/v3/repos/deployments/#parameters-1). |
 
 ## Action outputs
 
@@ -74,7 +75,7 @@ jobs:
         id: deployment
         with:
           token: "${{ github.token }}"
-          target_url: http://my-app-url.com
+          environment_url: http://my-app-url.com
           environment: production
 
       - name: Deploy my app
@@ -86,7 +87,7 @@ jobs:
         uses: chrnorm/deployment-status@releases/v1
         with:
           token: "${{ github.token }}"
-          target_url: http://my-app-url.com
+          environment_url: http://my-app-url.com
           state: "success"
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 
@@ -95,7 +96,7 @@ jobs:
         uses: chrnorm/deployment-status@releases/v1
         with:
           token: "${{ github.token }}"
-          target_url: http://my-app-url.com
+          environment_url: http://my-app-url.com
           state: "failure"
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
 ```

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "Creates a GitHub Deployment"
 author: "chrnorm"
 branding:
   icon: arrow-up
-  color: black
+  color: gray-dark
 inputs:
   initial_status:
     description: "Initial status for the deployment"
@@ -15,8 +15,14 @@ inputs:
   token:
     description: "Github repository token"
     required: true
+  log_url:
+    description: "Sets the URL for deployment output"
+    required: false
   target_url:
-    description: "Target url location"
+    description: "Same as log_url"
+    required: false
+  environment_url:
+    description: "Sets the URL for accessing your environment"
     required: false
   description:
     description: "Descriptive message about the deployment"

--- a/lib/main.js
+++ b/lib/main.js
@@ -21,12 +21,13 @@ function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
             const context = github.context;
-            const logUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}/checks`;
+            const defaultLogUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}/checks`;
             const token = core.getInput("token", { required: true });
             const ref = core.getInput("ref", { required: false }) || context.ref;
-            const url = core.getInput("target_url", { required: false }) || logUrl;
+            const logUrl = core.getInput("log_url", { required: false }) || core.getInput("target_url", { required: false }) || defaultLogUrl;
             const environment = core.getInput("environment", { required: false }) || "production";
             const description = core.getInput("description", { required: false });
+            const environmentUrl = core.getInput("environment_url", { required: false }) || "";
             const initialStatus = core.getInput("initial_status", {
                 required: false
             }) || "pending";
@@ -45,7 +46,7 @@ function run() {
                 auto_merge,
                 description
             });
-            yield client.repos.createDeploymentStatus(Object.assign({}, context.repo, { deployment_id: deployment.data.id, state: initialStatus, log_url: logUrl, environment_url: url }));
+            yield client.repos.createDeploymentStatus(Object.assign({}, context.repo, { deployment_id: deployment.data.id, state: initialStatus, log_url: logUrl, environment_url: environmentUrl }));
             core.setOutput("deployment_id", deployment.data.id.toString());
         }
         catch (error) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,14 +13,16 @@ type DeploymentState =
 async function run() {
   try {
     const context = github.context;
-    const logUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}/checks`;
+    const defaultLogUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/commit/${context.sha}/checks`;
 
     const token = core.getInput("token", { required: true });
     const ref = core.getInput("ref", { required: false }) || context.ref;
-    const url = core.getInput("target_url", { required: false }) || logUrl;
+    const logUrl = core.getInput("log_url", { required: false }) || core.getInput("target_url", { required: false }) || defaultLogUrl;
     const environment =
       core.getInput("environment", { required: false }) || "production";
     const description = core.getInput("description", { required: false });
+    const environmentUrl =
+      core.getInput("environment_url", { required: false }) || "";
     const initialStatus =
       (core.getInput("initial_status", {
         required: false
@@ -49,7 +51,7 @@ async function run() {
       deployment_id: deployment.data.id,
       state: initialStatus,
       log_url: logUrl,
-      environment_url: url
+      environment_url: environmentUrl
     });
 
     core.setOutput("deployment_id", deployment.data.id.toString());


### PR DESCRIPTION
Sync with https://github.com/chrnorm/deployment-status/pull/18

Breaking change: target_url is not used as environment_url anymore (to match GitHub API).