### PR TITLE
fix deprecated set-output warnings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.8.2",
+        "@actions/core": "^1.10.0",
         "@actions/github": "^5.0.3"
       },
       "devDependencies": {
@@ -28,11 +28,12 @@
       }
     },
     "node_modules/@actions/core": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.2.tgz",
-      "integrity": "sha512-FXcBL7nyik8K5ODeCKlxi+vts7torOkoDAKfeh61EAkAy1HAvwn9uVzZBY0f15YcQTcZZ2/iSGBFHEuioZWfDA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "dependencies": {
-        "@actions/http-client": "^2.0.1"
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/@actions/github": {
@@ -6043,6 +6044,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
@@ -6215,11 +6224,12 @@
   },
   "dependencies": {
     "@actions/core": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.8.2.tgz",
-      "integrity": "sha512-FXcBL7nyik8K5ODeCKlxi+vts7torOkoDAKfeh61EAkAy1HAvwn9uVzZBY0f15YcQTcZZ2/iSGBFHEuioZWfDA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==",
       "requires": {
-        "@actions/http-client": "^2.0.1"
+        "@actions/http-client": "^2.0.1",
+        "uuid": "^8.3.2"
       }
     },
     "@actions/github": {
@@ -10693,6 +10703,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Chris Norman",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.8.2",
+    "@actions/core": "^1.10.0",
     "@actions/github": "^5.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes warnings like:
```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```